### PR TITLE
add shinyjs:: to show/hide calls

### DIFF
--- a/shiny/shared/session/modules/appSteps/trackBrowser/modules/trackBrowserImage/trackBrowserImage_server.R
+++ b/shiny/shared/session/modules/appSteps/trackBrowser/modules/trackBrowserImage/trackBrowserImage_server.R
@@ -245,10 +245,10 @@ expansionPlot <- mdiInteractivePlotServer(
     contents = reactive({
         expandingTrack <- expandingTrack()
         if(is.list(expandingTrack)) {
-            show(selector = ".expansionImageWrapper")
-            createExpansionPlot(expandingTrack$trackId)         
+            shinyjs::show(selector = ".expansionImageWrapper")
+            createExpansionPlot(expandingTrack$trackId)
         } else {
-            hide(selector = ".expansionImageWrapper")
+            shinyjs::hide(selector = ".expansionImageWrapper")
             NULL 
         }
     })

--- a/shiny/shared/session/modules/appSteps/trackBrowser/trackBrowser_server.R
+++ b/shiny/shared/session/modules/appSteps/trackBrowser/trackBrowser_server.R
@@ -216,7 +216,7 @@ observeEvent(expansionTableData(), {
     toggle(selector = ".expansionTableWrapper", condition = isTruthy(expansionTableData()))
 }, ignoreNULL = FALSE)
 clearObjectExpansions <- function(){
-    hide(selector = ".browserExpansionWrapper")
+    shinyjs::hide(selector = ".browserExpansionWrapper")
     expandingTrack(NULL)
     for(regionI in 1:browser$nRegions()) browser$images[[regionI]]$expandingTrack(NULL)
     objectTableData(NULL)


### PR DESCRIPTION
An application using `genomex-mdi-tools` track browser inadvertently overrode the `shinyjs::show()` function, which was only being called as `show()`. These changes update all such calls to `shinyjs::show()`, `shinyjs::hide()`, and `shinyjs::toggle()` to prevent future collisions with common function names.